### PR TITLE
Add command history and streaming output features

### DIFF
--- a/kraftbot/core/agent.py
+++ b/kraftbot/core/agent.py
@@ -100,14 +100,14 @@ Format responses clearly with bullet points."""
         """
         try:
             result = await self.agent.run(prompt)
-            
+
             # Handle potential method vs property issue with result.output
             output_text = result.output
             if callable(output_text):
                 output_text = output_text()
-            
+
             return AgentResponse(response=str(output_text))
-                
+
         except Exception as e:
             # Provide more helpful error messages
             error_msg = str(e)
@@ -117,5 +117,25 @@ Format responses clearly with bullet points."""
                 error_msg = f"API Response Error: {error_msg}"
             elif "api key" in error_msg.lower():
                 error_msg = "API Key Error: Please check your OpenRouter API key is valid and has sufficient credits."
-            
+
             return AgentResponse(response=f"Error: {error_msg}")
+
+    async def run_stream(self, prompt: str, user_id: str = "user", session_id: str = "default"):
+        """
+        Run the agent with streaming output
+        """
+        try:
+            async with self.agent.run_stream(prompt) as stream:
+                async for token in stream:
+                    yield token
+        except Exception as e:
+            # Provide more helpful error messages
+            error_msg = str(e)
+            if "finish_reason" in error_msg and "error" in error_msg:
+                error_msg = "API Error: The model service returned an error response. This could be due to API limits, model availability, or service issues. Please try again or use a different model."
+            elif "validation error" in error_msg.lower():
+                error_msg = f"API Response Error: {error_msg}"
+            elif "api key" in error_msg.lower():
+                error_msg = "API Key Error: Please check your OpenRouter API key is valid and has sufficient credits."
+
+            yield f"Error: {error_msg}"


### PR DESCRIPTION
## Summary

This PR addresses two important UX improvements requested in the GitHub issues:

### ✅ Command History (Issue #3)
- **Feature**: Users can now press ↑/↓ arrow keys to navigate through previous commands
- **Implementation**: Replaced Rich `Prompt.ask()` with `prompt_toolkit` for full readline support
- **Benefits**: Standard terminal behavior that users expect from CLI tools

### ✅ Streaming Output (Issue #2) 
- **Feature**: Responses now stream token-by-token in real-time instead of appearing all at once
- **Implementation**: Added `run_stream()` method with Rich Live display updates
- **Benefits**: Better UX for long responses, real-time feedback, markdown formatting preserved

## Changes Made

### Command History Implementation
- Added `prompt_toolkit` with `InMemoryHistory` for session-based command recall
- Styled prompts with clear user feedback about navigation capabilities
- Maintains all existing Rich formatting and visual appeal

### Streaming Output Implementation
- **Agent Layer**: Added `async run_stream()` method to `PydanticAIAgent`
- **CLI Layer**: Created `display_streaming_response()` with Rich Live updates
- **Fallback**: Graceful degradation to non-streaming if streaming fails
- **Commands**: Updated both `chat` and `test` commands to use streaming

### Technical Architecture
- **Async Support**: Converted chat to async/sync wrapper pattern
- **Error Handling**: Comprehensive error handling for streaming failures
- **Markdown**: Real-time markdown rendering with responsive panel updates
- **Compatibility**: Maintains backward compatibility with existing interfaces

## Test Plan

- [x] Command history works with ↑/↓ arrow keys
- [x] Streaming displays tokens in real-time
- [x] Markdown formatting preserved during streaming
- [x] Fallback to non-streaming on errors
- [x] Both `chat` and `test` commands work correctly
- [x] Error handling works for API failures
- [x] Existing functionality preserved

## Demo Usage

### Command History
```bash
python main.py chat
# Type a command, press Enter
# Press ↑ to recall previous command
# Press ↓ to navigate forward in history
```

### Streaming Output
```bash
python main.py chat --prompt analytical
# Ask: "Should I start Justin Jefferson this week?"
# Watch response stream in real-time with markdown formatting
```

Fixes #3 and #2

🤖 Generated with [Claude Code](https://claude.ai/code)